### PR TITLE
125 suppport alll getposts api call arguments on block metadata calls

### DIFF
--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -40,4 +40,27 @@ class RESTEndpoints {
         $response->set_status(200);
         return $response;
     }
+
+    public static function get_all_post_block_meta($request) 
+    {
+        $args = array(
+            'numberposts' => -1
+        );
+        $posts = \get_posts($args);
+
+        $result = array();
+        foreach($posts as $post) {
+            $item_metadata = array();
+            $item_metadata['id'] = $post->ID;
+            $item_metadata['title'] = $post->post_title;
+            
+            $block_data = Data::get_block_data($post->post_content);
+            $block_metadata = Metadata::get_block_metadata($block_data);
+            $item_metadata['blocks'] = $block_metadata;
+            $result[] = $item_metadata;
+        }
+        $response = new \WP_REST_Response($result);
+        $response->set_status(200);
+        return $response;
+    }
 }

--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -49,14 +49,16 @@ class RESTEndpoints {
 
     public static function get_all_post_block_meta($request)
     {
+        $posts_per_page = 3000;
         $args = array(
-            'numberposts' => 3000
+            'numberposts' => $posts_per_page
         );
         $posts = \get_posts($args);
 
         $count_query = new \WP_Query();
         $count_query->query( array() );
         $total_posts  = $count_query->found_posts;
+        $total_pages = ceil( $total_posts / $posts_per_page );
 
         $result = array();
         foreach($posts as $post) {
@@ -71,6 +73,7 @@ class RESTEndpoints {
         }
         $response = new \WP_REST_Response($result);
         $response->header( 'X-WP-Total', (int) $total_posts );
+        $response->header( 'X-WP-TotalPages', (int) $total_pages );
         $response->set_status(200);
         return $response;
     }

--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -49,13 +49,8 @@ class RESTEndpoints {
 
     public static function get_all_post_block_meta($request)
     {
-        $posts_per_page = 3000;
-        $page = $request['page'];
-        $args = array(
-            'posts_per_page' => $posts_per_page,
-            'offset'         => $posts_per_page * $page,
-        );
-        $posts = \get_posts($args);
+        $params = $request->get_params();
+        $posts = \get_posts($params);
 
         $count_query = new \WP_Query();
         $count_query->query( array() );

--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -50,8 +50,10 @@ class RESTEndpoints {
     public static function get_all_post_block_meta($request)
     {
         $posts_per_page = 3000;
+        $page = $request['page'];
         $args = array(
-            'numberposts' => $posts_per_page
+            'posts_per_page' => $posts_per_page,
+            'offset'         => $posts_per_page * $page,
         );
         $posts = \get_posts($args);
 

--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -8,7 +8,7 @@ class RESTEndpoints {
      * @param [type] $request
      * @return void
      */
-    public static function get_post_blocks($request) 
+    public static function get_post_blocks($request)
     {
         $post = \get_post($request['post_id']);
         if (!$post) {
@@ -27,21 +27,27 @@ class RESTEndpoints {
      * @param [type] $request
      * @return void
      */
-    public static function get_post_block_meta($request) 
+    public static function get_post_block_meta($request)
     {
         $post = \get_post($request['post_id']);
         if (!$post) {
             return new \WP_Error('empty_post', 'There is no post with this ID', array('status' => 404));
         }
 
+        $item_metadata = array();
+        $item_metadata['id'] = $post->ID;
+        $item_metadata['title'] = $post->post_title;
+
         $block_data = Data::get_block_data($post->post_content);
         $block_metadata = Metadata::get_block_metadata($block_data);
-        $response = new \WP_REST_Response($block_metadata);
+        $item_metadata['blocks'] = $block_metadata;
+
+        $response = new \WP_REST_Response($item_metadata);
         $response->set_status(200);
         return $response;
     }
 
-    public static function get_all_post_block_meta($request) 
+    public static function get_all_post_block_meta($request)
     {
         $args = array(
             'numberposts' => -1
@@ -53,7 +59,7 @@ class RESTEndpoints {
             $item_metadata = array();
             $item_metadata['id'] = $post->ID;
             $item_metadata['title'] = $post->post_title;
-            
+
             $block_data = Data::get_block_data($post->post_content);
             $block_metadata = Metadata::get_block_metadata($block_data);
             $item_metadata['blocks'] = $block_metadata;

--- a/src/RESTEndpoints.php
+++ b/src/RESTEndpoints.php
@@ -50,9 +50,13 @@ class RESTEndpoints {
     public static function get_all_post_block_meta($request)
     {
         $args = array(
-            'numberposts' => -1
+            'numberposts' => 3000
         );
         $posts = \get_posts($args);
+
+        $count_query = new \WP_Query();
+        $count_query->query( array() );
+        $total_posts  = $count_query->found_posts;
 
         $result = array();
         foreach($posts as $post) {
@@ -66,6 +70,7 @@ class RESTEndpoints {
             $result[] = $item_metadata;
         }
         $response = new \WP_REST_Response($result);
+        $response->header( 'X-WP-Total', (int) $total_posts );
         $response->set_status(200);
         return $response;
     }

--- a/src/RESTHooks.php
+++ b/src/RESTHooks.php
@@ -27,5 +27,12 @@ class RESTHooks {
                 'callback' => [RESTEndpoints::class, 'get_post_block_meta']
             ]);
         });
+        \add_action('rest_api_init', function () {
+            // Endpoint: /wp-json/block-metadata/v1/metadata/
+            \register_rest_route(RESTUtils::get_namespace(), 'metadata', [
+                'methods'    => 'GET',
+                'callback' => [RESTEndpoints::class, 'get_all_post_block_meta']
+            ]);
+        });
     }
 }


### PR DESCRIPTION
I just pass all query parameters through to the get_posts call, so we support the same parameters as the get_posts call.